### PR TITLE
Replace references to non-existant kernel rbf with rbfard2

### DIFF
--- a/vargplvmR/R/gpOptions.R
+++ b/vargplvmR/R/gpOptions.R
@@ -39,11 +39,11 @@ gpOptions <-
       if (options$approx == "ftc") {
         ## bog-standard kernel.
         ## R version of the kern field is a more structured than in MATLAB.
-        options$kern = list(type="cmpnd",comp=list("rbf", "bias", "white"))
+        options$kern = list(type="cmpnd",comp=list("rbfard2", "bias", "white"))
         options$numActive = 0
         options$beta = list()
       } else if (options$approx %in% c('fitc', 'pitc', 'dtc', 'dtcvar')) {
-        options$kern = list(type="cmpnd",comp=list("rbf", "bias", "white"))
+        options$kern = list(type="cmpnd",comp=list("rbfard2", "bias", "white"))
         options$numActive = 100
         options$beta = 1e+3
         ## Option to fix the inducing variables to other latent points.
@@ -58,11 +58,11 @@ gpOptions <-
       if (options$approx == "ftc") {
         ## bog-standard kernel.
         ## R version of the kern field is a more structured than in MATLAB.
-        options$kern <- c("rbf", "bias", "white")
+        options$kern <- c("rbfard2", "bias", "white")
         options$numActive <- 0
         options$beta <- NULL
       } else if (options$approx %in% c("fitc", "pitc", "dtc", "dtcvar")) {
-        options$kern <- c("rbf", "bias", "white")
+        options$kern <- c("rbfard2", "bias", "white")
         options$numActive <- 100
         options$beta <- 1e+3
         ## Option to fix the inducing variables to other latent points.


### PR DESCRIPTION
The default options object causes errors in line 11 of [kernParamInit()](vargplvmR/R/KernParamInit.R) because of a reference to a non existent kernel.
